### PR TITLE
Register atexit handlers for balancedconsumer and producer

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -42,6 +42,7 @@ from .exceptions import (
 from .partitioners import random_partitioner
 from .protocol import Message, ProduceRequest
 from .utils.compat import iteritems, range, itervalues
+from .utils.common import unregister_cleanup_func, register_cleanup_func
 
 log = logging.getLogger(__name__)
 
@@ -140,6 +141,14 @@ class Producer(object):
         self._update_lock = self._cluster.handler.Lock()
         self.start()
 
+        def cleanup(obj):
+            if obj._running:
+                obj.stop()
+        self._cleanup_func = cleanup
+
+        # Register a cleanup handler
+        register_cleanup_func(self._cleanup_func, self)
+
     def _raise_worker_exceptions(self):
         """Raises exceptions encountered on worker threads"""
         if self._worker_exception is not None:
@@ -220,6 +229,10 @@ class Producer(object):
         if self._owned_brokers is not None:
             for owned_broker in self._owned_brokers.values():
                 owned_broker.stop()
+        # Unregister the cleanup handler
+        unregister_cleanup_func(self._cleanup_func, self)
+
+        del self._cleanup_func
 
     def produce(self, message, partition_key=None):
         """Produce a message.

--- a/pykafka/utils/common.py
+++ b/pykafka/utils/common.py
@@ -1,0 +1,23 @@
+import atexit
+
+
+def unregister_cleanup_func(cleanup, obj):
+    """Unregister the cleanup handler"""
+    if hasattr(obj, '_cleanup_func'):
+        # Remove cleanup handler now that we've stopped
+        try:
+            # py3 supports unregistering
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(cleanup) # pylint: disable=no-member
+            # py2 requires removing from private attribute...
+            else:
+                # ValueError on list.remove() if the exithandler no longer exists
+                # but that is fine here
+                atexit._exithandlers.remove((cleanup, (obj,), {}))
+        except ValueError:
+            pass
+
+
+def register_cleanup_func(cleanup, obj):
+    """Register a cleanup handler"""
+    atexit.register(cleanup, obj)

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -30,6 +30,13 @@ def buildMockConsumer(num_partitions=10, num_participants=1, timeout=2000):
                             consumer_timeout_ms=timeout), topic
 
 
+class MockAtexit(mock.MagicMock):
+    _exithandlers = []
+
+    def unregister(self, func):
+        raise ValueError
+
+
 class TestBalancedConsumer(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -48,6 +55,28 @@ class TestBalancedConsumer(unittest2.TestCase):
         """Ensure that stopping a consumer while consuming from Kafka does not
         end in an infinite loop when timeout is not used.
         """
+        consumer, _ = buildMockConsumer(timeout=-1)
+        consumer._setup_internal_consumer(start=False)
+
+        consumer.stop()
+        self.assertIsNone(consumer.consume())
+
+        # test that the stop() method is not called twice
+        self.assertFalse(hasattr(consumer, '_cleanup_func'))
+
+    def test_cleanup_stop_is_called_on_not_stopped_object(self):
+        """Test that the cleanup() method flushes the queue properly"""
+        consumer, _ = buildMockConsumer(timeout=-1)
+        consumer._setup_internal_consumer(start=False)
+
+        # simulates a program termination
+        consumer._cleanup_func(consumer)
+
+        self.assertIsNone(consumer.consume())
+
+    @mock.patch('pykafka.utils.common.atexit', new=MockAtexit())
+    def test_failing_to_remove_cleanup_func(self):
+        """Test ValueError is ignored """
         consumer, _ = buildMockConsumer(timeout=-1)
         consumer._setup_internal_consumer(start=False)
 

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -2,11 +2,19 @@ from __future__ import division
 
 import time
 import unittest2
+import mock
 from uuid import uuid4
 
 from pykafka import KafkaClient
 from pykafka.exceptions import ProducerQueueFullError
 from pykafka.test.utils import get_cluster, stop_cluster
+
+
+class MockAtexit(mock.MagicMock):
+    _exithandlers = []
+
+    def unregister(self, func):
+        raise ValueError
 
 
 class ProducerIntegrationTests(unittest2.TestCase):
@@ -118,6 +126,30 @@ class ProducerIntegrationTests(unittest2.TestCase):
         prod.produce(b"")  # empty string should be distinguished from None
         self.assertEqual(b"", self.consumer.consume().value)
 
+    def test_cleanup_stop_is_not_called_on_stopped_object(self):
+        """Test that the stop() method is not called twice"""
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.stop()
+        self.assertFalse(hasattr(prod, '_cleanup_func'))
+
+    def test_cleanup_stop_is_called_on_not_stopped_object(self):
+        """Test that the cleanup() method flushes the queue properly"""
+        payload = uuid4().bytes
+
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.produce(payload)
+        # simulates a program termination
+        prod._cleanup_func(prod)
+        # confirm that message was received
+        message = self.consumer.consume()
+        self.assertEqual(message.value, payload)
+
+    @mock.patch('pykafka.utils.common.atexit', new=MockAtexit())
+    def test_failing_to_remove_cleanup_func(self):
+        """Test ValueError is ignored """
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.stop()
+        self.assertFalse(hasattr(prod, '_cleanup_func'))
 
 if __name__ == "__main__":
     unittest2.main()


### PR DESCRIPTION
This makes sure that the `stop()` method is called properly at program termination.
